### PR TITLE
Fix overflow caused by float :math.pow

### DIFF
--- a/lib/custom_base.ex
+++ b/lib/custom_base.ex
@@ -1,6 +1,22 @@
 defmodule CustomBase do
   @moduledoc false
 
+  defmodule Pow do
+    @moduledoc false
+    # This is an integer-only implementation of pow
+    # It avoids issues where the erlang :math.pow overflows on a float
+    # but yet doesn't raise any errors
+
+    require Integer
+
+    def pow(_, 0), do: 1
+    def pow(x, n) when Integer.is_odd(n), do: x * pow(x, n - 1)
+    def pow(x, n) do
+      result = pow(x, div(n, 2))
+      result * result
+    end
+  end
+
   defmacro __using__(alphabet) do
     quote bind_quoted: [alphabet: alphabet] do
       for { digit, idx } <- Enum.with_index(alphabet) do
@@ -27,7 +43,6 @@ defmodule CustomBase do
         |> String.split("", trim: true)
         |> Enum.reverse
         |> decode(0)
-        |> round
       end
 
       for { digit, idx } <- Enum.with_index(alphabet) do
@@ -39,10 +54,10 @@ defmodule CustomBase do
       end
 
       defp decode([last], step) do
-        decode_char(last) * :math.pow(unquote(length(alphabet)), step)
+        decode_char(last) * Pow.pow(unquote(length(alphabet)), step)
       end
       defp decode([head|tail], step) do
-        decode_char(head) * :math.pow(unquote(length(alphabet)), step) + decode(tail, step + 1)
+        decode_char(head) * Pow.pow(unquote(length(alphabet)), step) + decode(tail, step + 1)
       end
     end
   end

--- a/test/custom_base_test.exs
+++ b/test/custom_base_test.exs
@@ -2,6 +2,10 @@ defmodule BaseABCDEFGHIJ do
   use CustomBase, 'abcdefghij'
 end
 
+defmodule HexBase do
+  use CustomBase, '0123456789abcdef'
+end
+
 defmodule CustomBaseTest do
   use ExUnit.Case
   import BaseABCDEFGHIJ
@@ -22,5 +26,14 @@ defmodule CustomBaseTest do
     assert decode!("c") == 2
     assert decode!("i") == 8
     assert decode!("gg") == 66
+  end
+
+  # This test will fail if :math.pow overflows
+  test "pow overflow" do
+    int = 489732498728927498273432
+    str = "67b473b32ffa144f0298" # Checked with WolframAlpha
+
+    assert str == HexBase.encode(int)
+    assert int == HexBase.decode!(str)
   end
 end


### PR DESCRIPTION
CustomBase silently fails to have matching encode/decode for very large inputs (that overflow the significand of the float).  So decode "appears" to work, but actually returns an incorrect value.  Encode is always correct.

This PR implements a basic integer-only pow to do the calculation.  Given alphabets and string lengths in the 1-100 range it is reasonably performant.

Also was able to remove the "round" since float no longer gets in the way.
